### PR TITLE
fix(services/error-handler): Update functionName to readonly

### DIFF
--- a/src/services/error-handler.service.ts
+++ b/src/services/error-handler.service.ts
@@ -32,7 +32,7 @@ type Type = NonPrimitiveType | PrimitiveType;
  * It supports different types of errors and generates dynamic messages.
  */
 class ErrorHandler {
-  private functionName: string;
+  private readonly functionName: string;
 
   constructor(functionName: string) {
     this.functionName = functionName;


### PR DESCRIPTION
update Member 'functionName' is never reassigned - mark it as readonly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the access modifier for the `functionName` property in the ErrorHandler class to enhance property immutability. 

This change improves code stability without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->