### PR TITLE
feat(hooks): useQueue hook

### DIFF
--- a/package/src/hooks/index.ts
+++ b/package/src/hooks/index.ts
@@ -3,3 +3,4 @@ export { usePrevious } from "./usePrevious/usePrevious";
 export { useWindowSize } from "./useWindowSize/useWindowSize";
 export { useCountdown } from "./useCountdown/useCountdown"
 export { useLocalStorage } from "./useLocalStorage/useLocalStorage";
+export { useQueue } from "./useQueue/useQueue";

--- a/package/src/hooks/useQueue/useQueue.test.ts
+++ b/package/src/hooks/useQueue/useQueue.test.ts
@@ -1,0 +1,59 @@
+// useQueue.test.ts
+
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useQueue } from './useQueue';
+
+describe('useQueue Hook', () => {
+  it('should enqueue items', () => {
+    const { result } = renderHook(() => useQueue<string>());
+
+    act(() => {
+      result.current.enqueue('item1');
+      result.current.enqueue('item2');
+    });
+
+    expect(result.current.items).toEqual(['item1', 'item2']);
+    expect(result.current.size).toBe(2);
+  });
+
+  it('should dequeue items', () => {
+    const { result } = renderHook(() => useQueue<string>());
+
+    act(() => {
+      result.current.enqueue('item1');
+      result.current.enqueue('item2');
+    });
+
+    act(() => {
+      result.current.dequeue(); // This should remove 'item1'
+    });
+
+    expect(result.current.items).toEqual(['item2']); // Now only 'item2' should remain
+    expect(result.current.size).toBe(1); // Size should be 1 after dequeue
+  });
+
+  it('should return undefined when dequeue is called on an empty queue', () => {
+    const { result } = renderHook(() => useQueue<string>());
+
+    let dequeuedItem;
+    act(() => {
+      dequeuedItem = result.current.dequeue();
+    });
+
+    expect(dequeuedItem).toBeUndefined();
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('should clear the queue', () => {
+    const { result } = renderHook(() => useQueue<string>());
+
+    act(() => {
+      result.current.enqueue('item1');
+      result.current.enqueue('item2');
+      result.current.clear();
+    });
+
+    expect(result.current.items).toEqual([]);
+    expect(result.current.size).toBe(0);
+  });
+});

--- a/package/src/hooks/useQueue/useQueue.ts
+++ b/package/src/hooks/useQueue/useQueue.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+type Queue<T> = {
+  enqueue: (item: T) => void;
+  dequeue: () => T | undefined;
+  peek: () => T | undefined;
+  isEmpty: () => boolean;
+  clear: () => void;
+  size: number;
+  items: T[];
+};
+
+export function useQueue<T>(): Queue<T> {
+  const [queue, setQueue] = useState<T[]>([]);
+
+  const enqueue = (item: T) => {
+    setQueue((prevQueue) => [...prevQueue, item]);
+  };
+
+  const dequeue = () => {
+    if (queue.length === 0) return undefined;
+    const [firstItem, ...rest] = queue;
+    setQueue(rest);
+    return firstItem;
+  };
+
+  const peek = () => {
+    return queue.length > 0 ? queue[0] : undefined;
+  };
+
+  const isEmpty = () => queue.length === 0;
+
+  const clear = () => setQueue([]);
+
+  return {
+    enqueue,
+    dequeue,
+    peek,
+    isEmpty,
+    clear,
+    size: queue.length,
+    items: queue,
+  };
+}

--- a/smart-app/src/App.tsx
+++ b/smart-app/src/App.tsx
@@ -3,7 +3,7 @@ import { SectionWrapper } from "./components/common/section-wrapper";
 import UseCountDown from "./components/hooks/UseCountdown";
 import UseLocalStorage from "./components/hooks/UseLocalStorage";
 import UsePrevious from "./components/hooks/UsePrevious";
-
+import UseQueue from "./components/hooks/UseQueue";
 function App() {
   const rsu = [
     {
@@ -21,7 +21,10 @@ function App() {
           title: "UseLocalStorage",
           node: <UseLocalStorage />,
         },
-        
+        {
+          title: "UseQueue",
+          node: <UseQueue />,
+        },
       ],
     },
     {

--- a/smart-app/src/components/hooks/UseQueue.tsx
+++ b/smart-app/src/components/hooks/UseQueue.tsx
@@ -1,0 +1,39 @@
+// UseQueue.tsx
+
+import React, { useState } from 'react';
+import { useQueue } from '../../../../package/src/hooks/useQueue/useQueue'; 
+
+const UseQueueComponent: React.FC = () => {
+  const [inputValue, setInputValue] = useState('');
+  const queue = useQueue<string>(); 
+
+  const handleEnqueue = () => {
+    if (inputValue.trim() === '') return;
+    queue.enqueue(inputValue);
+    setInputValue('');
+  };
+
+  return (
+    <div>
+      <h1>Queue Example</h1>
+      <input
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        placeholder="Add to queue"
+      />
+      <button onClick={handleEnqueue}>Enqueue</button>
+      <button onClick={queue.dequeue}>Dequeue</button>
+      <button onClick={queue.clear}>Clear Queue</button>
+
+      <h2>Queue Size: {queue.size}</h2>
+      <ul>
+        {queue.items.map((item, index) => (
+          <li key={index}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default UseQueueComponent;


### PR DESCRIPTION
This PR introduces a custom React hook, useQueue, that provides an efficient way to manage a queue data structure within components. The hook facilitates enqueueing and dequeueing of items, allowing components to handle tasks in a first-in, first-out (FIFO) manner. It offers an intuitive API for interacting with the queue, including functionalities to peek at the front item, check if the queue is empty, and clear the queue entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new custom hook `useQueue` for managing a queue with functionalities like enqueue, dequeue, peek, and clear.
	- Added a `UseQueue` component that allows users to interact with the queue through a user-friendly interface, including enqueueing and dequeuing items.
- **Tests**
	- Implemented unit tests for the `useQueue` hook to ensure expected behavior across various scenarios.
- **Documentation**
	- Updated the app structure to include the new `UseQueue` component in the main application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->