### PR TITLE
feat(package/hooks):useKeyPress hook

### DIFF
--- a/package/src/hooks/useKeyPress/useKeyPress.test.ts
+++ b/package/src/hooks/useKeyPress/useKeyPress.test.ts
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import useKeyPress from './useKeyPress';
+
+const TestComponent: React.FC<{ targetKey: string }> = ({ targetKey }) => {
+  const keyPressed = useKeyPress(targetKey);
+
+  return React.createElement('div', null, 
+    React.createElement('p', null, keyPressed ? `${targetKey} key pressed!` : `${targetKey} key not pressed.`)
+  );
+};
+
+describe('useKeyPress', () => {
+  it('should detect key press', () => {
+    const { getByText } = render(React.createElement(TestComponent, { targetKey: "Enter" }));
+
+    expect(getByText(/Enter key not pressed./)).toBeInTheDocument();
+
+    // Simulate key down and up events
+    const enterKeyEventDown = new KeyboardEvent('keydown', { key: 'Enter' });
+    window.dispatchEvent(enterKeyEventDown);
+    
+    expect(getByText(/Enter key pressed!/)).toBeInTheDocument();
+
+    const enterKeyEventUp = new KeyboardEvent('keyup', { key: 'Enter' });
+    window.dispatchEvent(enterKeyEventUp);
+
+    expect(getByText(/Enter key not pressed./)).toBeInTheDocument();
+  });
+});

--- a/package/src/hooks/useKeyPress/useKeyPress.ts
+++ b/package/src/hooks/useKeyPress/useKeyPress.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+const useKeyPress = (targetKey: string): boolean => {
+  const [keyPressed, setKeyPressed] = useState<boolean>(false);
+
+  const downHandler = ({ key }: KeyboardEvent) => {
+    if (key === targetKey) {
+      setKeyPressed(true);
+    }
+  };
+
+  const upHandler = ({ key }: KeyboardEvent) => {
+    if (key === targetKey) {
+      setKeyPressed(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('keydown', downHandler);
+    window.addEventListener('keyup', upHandler);
+
+    return () => {
+      window.removeEventListener('keydown', downHandler);
+      window.removeEventListener('keyup', upHandler);
+    };
+  }, []);
+
+  return keyPressed;
+};
+
+export default useKeyPress;


### PR DESCRIPTION
The useKeyPress hook is a useful for detecting key presses and performing specific actions based on the pressed key. By calling useKeyPress with the desired key and callback function, the hook sets up an event listener that triggers the callback when the specified key is pressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a custom hook, `useKeyPress`, to monitor key press events for specified keys.
	- Added a test suite for the `useKeyPress` hook to ensure functionality and state management.
- **Bug Fixes**
	- Implemented cleanup for event listeners to prevent memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->