### PR TITLE
Add useDisclosure Hook

### DIFF
--- a/package/src/hooks/index.ts
+++ b/package/src/hooks/index.ts
@@ -1,5 +1,6 @@
-export { useToggle } from "./useToggle/useToggle";
-export { usePrevious } from "./usePrevious/usePrevious";
-export { useWindowSize } from "./useWindowSize/useWindowSize";
-export { useCountdown } from "./useCountdown/useCountdown"
-export { useLocalStorage } from "./useLocalStorage/useLocalStorage";
+export { useCountdown } from './useCountdown/useCountdown';
+export { useDisclosure } from './useDisclosure/useDisclosure';
+export { useLocalStorage } from './useLocalStorage/useLocalStorage';
+export { usePrevious } from './usePrevious/usePrevious';
+export { useToggle } from './useToggle/useToggle';
+export { useWindowSize } from './useWindowSize/useWindowSize';

--- a/package/src/hooks/useDisclosure/useDisclosure.test.ts
+++ b/package/src/hooks/useDisclosure/useDisclosure.test.ts
@@ -1,0 +1,36 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useDisclosure } from './useDisclosure';
+
+describe('useDisclosure Hook', () => {
+  it('should initialize with the default value (false)', () => {
+    const { result } = renderHook(() => useDisclosure());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('should initialize with a provided initial value (true)', () => {
+    const { result } = renderHook(() => useDisclosure(true));
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('should set isOpen to true when open is called', () => {
+    const { result } = renderHook(() => useDisclosure());
+    act(() => result.current.open());
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('should set isOpen to false when close is called', () => {
+    const { result } = renderHook(() => useDisclosure(true));
+    act(() => result.current.close());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('should toggle isOpen when toggle is called', () => {
+    const { result } = renderHook(() => useDisclosure());
+
+    act(() => result.current.toggle());
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => result.current.toggle());
+    expect(result.current.isOpen).toBe(false);
+  });
+});

--- a/package/src/hooks/useDisclosure/useDisclosure.ts
+++ b/package/src/hooks/useDisclosure/useDisclosure.ts
@@ -1,0 +1,13 @@
+import { useCallback, useState } from 'react';
+
+export const useDisclosure = (initialValue: boolean = false) => {
+  const [isOpen, setIsOpen] = useState(initialValue);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
+
+  return { isOpen, open, close, toggle };
+};
+
+export type UseDisclosureReturn = ReturnType<typeof useDisclosure>;


### PR DESCRIPTION
The `useDisclosure` hook is designed to simplify managing components like Modals, Dialogs, and Drawers by providing an `isOpen` state and utility functions: `open`, `close`, and `toggle`. These functions offer easy, boilerplate-free control over the component's visibility state.

The hook and tests are included. Let me know if there's anything else required!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new custom hook, `useDisclosure`, for managing the open/close state of disclosure components (e.g., modals, dropdowns).
	- Added functionality to initialize the disclosure state with a custom value.
	- Provided methods to open, close, and toggle the disclosure state.

- **Tests**
	- Implemented a comprehensive test suite for the `useDisclosure` hook, covering initialization and state management functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->