### PR TITLE
feat(hooks):useUnmount hook

### DIFF
--- a/package/src/hooks/useUnmount/useUnmount.test.ts
+++ b/package/src/hooks/useUnmount/useUnmount.test.ts
@@ -1,14 +1,40 @@
-import { useCallback, useEffect } from "react";
-export const useUnmount = (callback: () => void, deps: any[] = [] ) => {
-    useEffect(() => {
-        return () => {
-            callback();
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useUnmount } from './useUnmount'; // Adjust the import based on your project structure
 
-        };
-    }, deps);
-};
-const dependency: any ={};
+describe('useUnmount', () => {
+  it('should call the callback when the component unmounts', () => {
+    const mockCallback = jest.fn();
+    
+    const { unmount } = renderHook(() => useUnmount(mockCallback));
+    
+    // Unmount the hook
+    unmount();
+    
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+  });
 
-useUnmount(() =>{
-    console.log ("component unmounted");
-},[dependency]);
+  it('should not throw an error when the callback executes successfully', () => {
+    const mockCallback = jest.fn();
+
+    const { unmount } = renderHook(() => useUnmount(mockCallback));
+    
+    expect(() => unmount()).not.toThrow();
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should catch errors thrown by the callback', () => {
+    const mockCallback = jest.fn(() => {
+      throw new Error('Test error');
+    });
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { unmount } = renderHook(() => useUnmount(mockCallback));
+    
+    expect(() => unmount()).not.toThrow();
+    
+    // Check if console.error was called with the correct message
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error in unmount callback', expect.any(Error));
+    
+    consoleErrorSpy.mockRestore(); // Restore the original console.error
+  });
+});

--- a/package/src/hooks/useUnmount/useUnmount.test.ts
+++ b/package/src/hooks/useUnmount/useUnmount.test.ts
@@ -1,0 +1,14 @@
+import { useCallback, useEffect } from "react";
+export const useUnmount = (callback: () => void, deps: any[] = [] ) => {
+    useEffect(() => {
+        return () => {
+            callback();
+
+        };
+    }, deps);
+};
+const dependency: any ={};
+
+useUnmount(() =>{
+    console.log ("component unmounted");
+},[dependency]);

--- a/package/src/hooks/useUnmount/useUnmount.ts
+++ b/package/src/hooks/useUnmount/useUnmount.ts
@@ -1,14 +1,13 @@
-import {useEffect} from "react";
+import { useEffect } from "react";
 
-export const useUnmount =(callback :()=> void , deps: any []=[]) =>{
-    useEffect(() => {
-        return() => {
-            callback();
-        };
-    }, deps);
+export const useUnmount = (callback: () => void) => {
+  useEffect(() => {
+    return () => {
+      try {
+        callback();
+      } catch (error) {
+        console.error("Error in unmount callback", error);
+      }
+    };
+  }, []);
 };
-const dependency: any ={};
-useUnmount(() => {
-    console.log("Component unmounted");
-
-},[dependency]);

--- a/package/src/hooks/useUnmount/useUnmount.ts
+++ b/package/src/hooks/useUnmount/useUnmount.ts
@@ -1,0 +1,14 @@
+import {useEffect} from "react";
+
+export const useUnmount =(callback :()=> void , deps: any []=[]) =>{
+    useEffect(() => {
+        return() => {
+            callback();
+        };
+    }, deps);
+};
+const dependency: any ={};
+useUnmount(() => {
+    console.log("Component unmounted");
+
+},[dependency]);

--- a/package/src/types/useUnmount.d.ts
+++ b/package/src/types/useUnmount.d.ts
@@ -1,0 +1,12 @@
+
+
+declare module "hooks" {
+  /**
+   * The `useUnmount` hook returns a boolean state value and a function to toggle that value.
+   *
+   *  @param callback - The `callback` parameter in the `useUnmount` function is a function that will be
+   * executed when the component using this hook is unmounted. It is a function that you pass to
+   * `useUnmount` to perform cleanup or any necessary actions before the component is removed from the DOM.
+   */
+  export function useUnmount(callback: () => void): void;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a custom React hook, `useUnmount`, that allows users to execute a callback function when a component unmounts, enhancing component lifecycle management.
	- Added error handling to ensure that exceptions during callback execution are logged without disrupting the unmounting process.

- **Tests**
	- Added test cases for the `useUnmount` hook to validate its functionality and error handling during component unmounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->